### PR TITLE
Show how global policies can catch gaps in specific policy sets

### DIFF
--- a/aws-restrict-instance-type-default.sentinel
+++ b/aws-restrict-instance-type-default.sentinel
@@ -1,0 +1,38 @@
+import "tfplan"
+
+# Get all AWS instances from all modules
+get_aws_instances = func() {
+    instances = []
+    for tfplan.module_paths as path {
+        instances += values(tfplan.module(path).resources.aws_instance) else []
+    }
+    return instances
+}
+
+# Allowed Types
+allowed_types = [
+  "t2.nano",
+  "t2.micro",
+  "t2.small",
+  "t2.medium",
+  "t2.large",
+  "t2.xlarge",
+  "m4.large",
+  "m4.xlarge",
+]
+
+aws_instances = get_aws_instances()
+
+# Rule to restrict instance types
+instance_type_allowed = rule {
+    all aws_instances as _, instances {
+      all instances as index, r {
+  	   r.applied.instance_type in allowed_types
+      }
+    }
+}
+
+# Main rule that requires other rules to be true
+main = rule {
+  (instance_type_allowed) else true
+}

--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,7 @@ resource "tfe_policy_set" "global" {
     "${tfe_sentinel_policy.aws-block-allow-all-cidr.id}",
     "${tfe_sentinel_policy.azurerm-block-allow-all-cidr.id}",
     "${tfe_sentinel_policy.gcp-block-allow-all-cidr.id}",
+    "${tfe_sentinel_policy.aws-restrict-instance-type-default.id}",
     "${tfe_sentinel_policy.azurerm-restrict-vm-size.id}",
     "${tfe_sentinel_policy.gcp-restrict-machine-type.id}",
   ]
@@ -66,7 +67,6 @@ resource "tfe_policy_set" "production" {
 
   workspace_external_ids = [
     "${var.tfe_workspace_ids["app-prod"]}",
-    "${var.tfe_workspace_ids["app-staging"]}",
   ]
 }
 
@@ -139,9 +139,17 @@ resource "tfe_sentinel_policy" "aws-restrict-instance-type-prod" {
   enforce_mode = "soft-mandatory"
 }
 
+resource "tfe_sentinel_policy" "aws-restrict-instance-type-default" {
+  name         = "aws-restrict-instance-type-default"
+  description  = "Limit AWS instances to approved list"
+  organization = "${var.tfe_organization}"
+  policy       = "${file("./aws-restrict-instance-type-default.sentinel")}"
+  enforce_mode = "soft-mandatory"
+}
+
 resource "tfe_sentinel_policy" "azurerm-restrict-vm-size" {
   name         = "azurerm-restrict-vm-size"
-  description  = "Limit Azure instances to approved list (for prod infrastructure)"
+  description  = "Limit Azure instances to approved list"
   organization = "${var.tfe_organization}"
   policy       = "${file("./azurerm-restrict-vm-size.sentinel")}"
   enforce_mode = "soft-mandatory"
@@ -149,7 +157,7 @@ resource "tfe_sentinel_policy" "azurerm-restrict-vm-size" {
 
 resource "tfe_sentinel_policy" "gcp-restrict-machine-type" {
   name         = "gcp-restrict-machine-type"
-  description  = "Limit GCP instances to approved list (for prod infrastructure)"
+  description  = "Limit GCP instances to approved list"
   organization = "${var.tfe_organization}"
   policy       = "${file("./gcp-restrict-machine-type.sentinel")}"
   enforce_mode = "soft-mandatory"


### PR DESCRIPTION
Doing this with sentinel code can get a little wordy, but the goal is to show how you can have more restrictive variants on a policy for certain types of infrastructure. 