### PR TITLE
Refactor out the nested `all` expressions in policies

### DIFF
--- a/aws-block-allow-all-cidr.sentinel
+++ b/aws-block-allow-all-cidr.sentinel
@@ -1,30 +1,42 @@
 import "tfplan"
 
-# Flatten tfplan's nested resource maps:
-#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
-# ...to an array of resource bodies:
-#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
-get_resource_bodies = func(named_and_counted_resources) {
-	result = []
-	for named_and_counted_resources as _, instances {
-		for instances as _, body {
-			append(result, body)
-		}
-	}
-	return result
-}
-
 # Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
-		for tfplan.module_paths as path {
-			nested_resources = tfplan.module(path).resources[type] else {}
-			resources += get_resource_bodies(nested_resources)
-		}
+		return get_resources_all_modules(type)
 	} else { # fallback for tests
-		nested_resources = tfplan.resources[type] else {}
-		resources += get_resource_bodies(nested_resources)
+		return get_resources_root_only(type)
+	}
+}
+
+get_resources_root_only = func(type) {
+	resources = []
+	named_and_counted_resources = tfplan.resources[type] else {}
+	# Get resource bodies out of nested resource maps, from:
+	# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+	# to:
+	# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(resources, body)
+		}
+	}
+	return resources
+}
+
+get_resources_all_modules = func(type) {
+	resources = []
+	for tfplan.module_paths as path {
+		named_and_counted_resources = tfplan.module(path).resources[type] else {}
+		# Get resource bodies out of nested resource maps, from:
+		# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+		# to:
+		# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+		for named_and_counted_resources as _, instances {
+			for instances as _, body {
+				append(resources, body)
+			}
+		}
 	}
 	return resources
 }

--- a/aws-block-allow-all-cidr.sentinel
+++ b/aws-block-allow-all-cidr.sentinel
@@ -1,36 +1,43 @@
 import "tfplan"
 
-# Get an array of resource bodies of the given type (each body indexed by count),
-# collected from all modules. (Returns an empty array if none found).
-# Outline of structure:
-# [ {"0": {"applied": {"instance_type": "..."}, "diff": {...}}, "1": {...}},
-#   {"0": {...}},
-#   ... ]
+# Flatten tfplan's nested resource maps:
+#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+# ...to an array of resource bodies:
+#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+get_resource_bodies = func(named_and_counted_resources) {
+	result = []
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(result, body)
+		}
+	}
+	return result
+}
+
+# Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	instances = []
+	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
 		for tfplan.module_paths as path {
-			instances += values(tfplan.module(path).resources[type]) else []
+			nested_resources = tfplan.module(path).resources[type] else {}
+			resources += get_resource_bodies(nested_resources)
 		}
 	} else { # fallback for tests
-		instances += values(tfplan.resources[type]) else []
+		nested_resources = tfplan.resources[type] else {}
+		resources += get_resource_bodies(nested_resources)
 	}
-	return instances
+	return resources
 }
 
 disallowed_cidr_blocks = [
 	"0.0.0.0/0",
 ]
 
-security_groups = get_resources("aws_security_group")
-
 main = rule {
-	all security_groups as _index, instances {
-		all instances as _count, sg {
-			all sg.applied.ingress as ingress {
-				all disallowed_cidr_blocks as block {
-					ingress.cidr_blocks not contains block
-				}
+	all get_resources("aws_security_group") as sg {
+		all sg.applied.ingress as ingress {
+			all disallowed_cidr_blocks as block {
+				ingress.cidr_blocks not contains block
 			}
 		}
 	}

--- a/aws-restrict-instance-type-default.sentinel
+++ b/aws-restrict-instance-type-default.sentinel
@@ -1,30 +1,42 @@
 import "tfplan"
 
-# Flatten tfplan's nested resource maps:
-#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
-# ...to an array of resource bodies:
-#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
-get_resource_bodies = func(named_and_counted_resources) {
-	result = []
-	for named_and_counted_resources as _, instances {
-		for instances as _, body {
-			append(result, body)
-		}
-	}
-	return result
-}
-
 # Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
-		for tfplan.module_paths as path {
-			nested_resources = tfplan.module(path).resources[type] else {}
-			resources += get_resource_bodies(nested_resources)
-		}
+		return get_resources_all_modules(type)
 	} else { # fallback for tests
-		nested_resources = tfplan.resources[type] else {}
-		resources += get_resource_bodies(nested_resources)
+		return get_resources_root_only(type)
+	}
+}
+
+get_resources_root_only = func(type) {
+	resources = []
+	named_and_counted_resources = tfplan.resources[type] else {}
+	# Get resource bodies out of nested resource maps, from:
+	# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+	# to:
+	# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(resources, body)
+		}
+	}
+	return resources
+}
+
+get_resources_all_modules = func(type) {
+	resources = []
+	for tfplan.module_paths as path {
+		named_and_counted_resources = tfplan.module(path).resources[type] else {}
+		# Get resource bodies out of nested resource maps, from:
+		# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+		# to:
+		# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+		for named_and_counted_resources as _, instances {
+			for instances as _, body {
+				append(resources, body)
+			}
+		}
 	}
 	return resources
 }

--- a/aws-restrict-instance-type-default.sentinel
+++ b/aws-restrict-instance-type-default.sentinel
@@ -1,21 +1,32 @@
 import "tfplan"
 
-# Get an array of resource bodies of the given type (each body indexed by count),
-# collected from all modules. (Returns an empty array if none found).
-# Outline of structure:
-# [ {"0": {"applied": {"instance_type": "..."}, "diff": {...}}, "1": {...}},
-#   {"0": {...}},
-#   ... ]
+# Flatten tfplan's nested resource maps:
+#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+# ...to an array of resource bodies:
+#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+get_resource_bodies = func(named_and_counted_resources) {
+	result = []
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(result, body)
+		}
+	}
+	return result
+}
+
+# Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	instances = []
+	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
 		for tfplan.module_paths as path {
-			instances += values(tfplan.module(path).resources[type]) else []
+			nested_resources = tfplan.module(path).resources[type] else {}
+			resources += get_resource_bodies(nested_resources)
 		}
 	} else { # fallback for tests
-		instances += values(tfplan.resources[type]) else []
+		nested_resources = tfplan.resources[type] else {}
+		resources += get_resource_bodies(nested_resources)
 	}
-	return instances
+	return resources
 }
 
 # Allowed Types
@@ -30,14 +41,10 @@ allowed_types = [
 	"m4.xlarge",
 ]
 
-aws_instances = get_resources("aws_instance")
-
 # Rule to restrict instance types
 instance_type_allowed = rule {
-	all aws_instances as _index, instances {
-		all instances as _count, r {
-			r.applied.instance_type in allowed_types
-		}
+	all get_resources("aws_instance") as r {
+		r.applied.instance_type in allowed_types
 	}
 }
 

--- a/aws-restrict-instance-type-dev.sentinel
+++ b/aws-restrict-instance-type-dev.sentinel
@@ -1,30 +1,42 @@
 import "tfplan"
 
-# Flatten tfplan's nested resource maps:
-#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
-# ...to an array of resource bodies:
-#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
-get_resource_bodies = func(named_and_counted_resources) {
-	result = []
-	for named_and_counted_resources as _, instances {
-		for instances as _, body {
-			append(result, body)
-		}
-	}
-	return result
-}
-
 # Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
-		for tfplan.module_paths as path {
-			nested_resources = tfplan.module(path).resources[type] else {}
-			resources += get_resource_bodies(nested_resources)
-		}
+		return get_resources_all_modules(type)
 	} else { # fallback for tests
-		nested_resources = tfplan.resources[type] else {}
-		resources += get_resource_bodies(nested_resources)
+		return get_resources_root_only(type)
+	}
+}
+
+get_resources_root_only = func(type) {
+	resources = []
+	named_and_counted_resources = tfplan.resources[type] else {}
+	# Get resource bodies out of nested resource maps, from:
+	# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+	# to:
+	# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(resources, body)
+		}
+	}
+	return resources
+}
+
+get_resources_all_modules = func(type) {
+	resources = []
+	for tfplan.module_paths as path {
+		named_and_counted_resources = tfplan.module(path).resources[type] else {}
+		# Get resource bodies out of nested resource maps, from:
+		# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+		# to:
+		# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+		for named_and_counted_resources as _, instances {
+			for instances as _, body {
+				append(resources, body)
+			}
+		}
 	}
 	return resources
 }

--- a/aws-restrict-instance-type-dev.sentinel
+++ b/aws-restrict-instance-type-dev.sentinel
@@ -1,21 +1,32 @@
 import "tfplan"
 
-# Get an array of resource bodies of the given type (each body indexed by count),
-# collected from all modules. (Returns an empty array if none found).
-# Outline of structure:
-# [ {"0": {"applied": {"instance_type": "..."}, "diff": {...}}, "1": {...}},
-#   {"0": {...}},
-#   ... ]
+# Flatten tfplan's nested resource maps:
+#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+# ...to an array of resource bodies:
+#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+get_resource_bodies = func(named_and_counted_resources) {
+	result = []
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(result, body)
+		}
+	}
+	return result
+}
+
+# Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	instances = []
+	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
 		for tfplan.module_paths as path {
-			instances += values(tfplan.module(path).resources[type]) else []
+			nested_resources = tfplan.module(path).resources[type] else {}
+			resources += get_resource_bodies(nested_resources)
 		}
 	} else { # fallback for tests
-		instances += values(tfplan.resources[type]) else []
+		nested_resources = tfplan.resources[type] else {}
+		resources += get_resource_bodies(nested_resources)
 	}
-	return instances
+	return resources
 }
 
 # Allowed Types
@@ -26,14 +37,10 @@ allowed_types = [
 	"t2.medium",
 ]
 
-aws_instances = get_resources("aws_instance")
-
 # Rule to restrict instance types
 instance_type_allowed = rule {
-	all aws_instances as _index, instances {
-		all instances as _count, r {
-			r.applied.instance_type in allowed_types
-		}
+	all get_resources("aws_instance") as r {
+		r.applied.instance_type in allowed_types
 	}
 }
 

--- a/aws-restrict-instance-type-prod.sentinel
+++ b/aws-restrict-instance-type-prod.sentinel
@@ -1,21 +1,32 @@
 import "tfplan"
 
-# Get an array of resource bodies of the given type (each body indexed by count),
-# collected from all modules. (Returns an empty array if none found).
-# Outline of structure:
-# [ {"0": {"applied": {"instance_type": "..."}, "diff": {...}}, "1": {...}},
-#   {"0": {...}},
-#   ... ]
+# Flatten tfplan's nested resource maps:
+#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+# ...to an array of resource bodies:
+#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+get_resource_bodies = func(named_and_counted_resources) {
+	result = []
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(result, body)
+		}
+	}
+	return result
+}
+
+# Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	instances = []
+	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
 		for tfplan.module_paths as path {
-			instances += values(tfplan.module(path).resources[type]) else []
+			nested_resources = tfplan.module(path).resources[type] else {}
+			resources += get_resource_bodies(nested_resources)
 		}
 	} else { # fallback for tests
-		instances += values(tfplan.resources[type]) else []
+		nested_resources = tfplan.resources[type] else {}
+		resources += get_resource_bodies(nested_resources)
 	}
-	return instances
+	return resources
 }
 
 # Allowed Types
@@ -28,14 +39,10 @@ allowed_types = [
 	"m4.xlarge",
 ]
 
-aws_instances = get_resources("aws_instance")
-
 # Rule to restrict instance types
 instance_type_allowed = rule {
-	all aws_instances as _index, instances {
-		all instances as _count, r {
-			r.applied.instance_type in allowed_types
-		}
+	all get_resources("aws_instance") as r {
+		r.applied.instance_type in allowed_types
 	}
 }
 

--- a/aws-restrict-instance-type-prod.sentinel
+++ b/aws-restrict-instance-type-prod.sentinel
@@ -1,30 +1,42 @@
 import "tfplan"
 
-# Flatten tfplan's nested resource maps:
-#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
-# ...to an array of resource bodies:
-#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
-get_resource_bodies = func(named_and_counted_resources) {
-	result = []
-	for named_and_counted_resources as _, instances {
-		for instances as _, body {
-			append(result, body)
-		}
-	}
-	return result
-}
-
 # Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
-		for tfplan.module_paths as path {
-			nested_resources = tfplan.module(path).resources[type] else {}
-			resources += get_resource_bodies(nested_resources)
-		}
+		return get_resources_all_modules(type)
 	} else { # fallback for tests
-		nested_resources = tfplan.resources[type] else {}
-		resources += get_resource_bodies(nested_resources)
+		return get_resources_root_only(type)
+	}
+}
+
+get_resources_root_only = func(type) {
+	resources = []
+	named_and_counted_resources = tfplan.resources[type] else {}
+	# Get resource bodies out of nested resource maps, from:
+	# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+	# to:
+	# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(resources, body)
+		}
+	}
+	return resources
+}
+
+get_resources_all_modules = func(type) {
+	resources = []
+	for tfplan.module_paths as path {
+		named_and_counted_resources = tfplan.module(path).resources[type] else {}
+		# Get resource bodies out of nested resource maps, from:
+		# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+		# to:
+		# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+		for named_and_counted_resources as _, instances {
+			for instances as _, body {
+				append(resources, body)
+			}
+		}
 	}
 	return resources
 }

--- a/azurerm-block-allow-all-cidr.sentinel
+++ b/azurerm-block-allow-all-cidr.sentinel
@@ -1,30 +1,42 @@
 import "tfplan"
 
-# Flatten tfplan's nested resource maps:
-#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
-# ...to an array of resource bodies:
-#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
-get_resource_bodies = func(named_and_counted_resources) {
-	result = []
-	for named_and_counted_resources as _, instances {
-		for instances as _, body {
-			append(result, body)
-		}
-	}
-	return result
-}
-
 # Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
-		for tfplan.module_paths as path {
-			nested_resources = tfplan.module(path).resources[type] else {}
-			resources += get_resource_bodies(nested_resources)
-		}
+		return get_resources_all_modules(type)
 	} else { # fallback for tests
-		nested_resources = tfplan.resources[type] else {}
-		resources += get_resource_bodies(nested_resources)
+		return get_resources_root_only(type)
+	}
+}
+
+get_resources_root_only = func(type) {
+	resources = []
+	named_and_counted_resources = tfplan.resources[type] else {}
+	# Get resource bodies out of nested resource maps, from:
+	# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+	# to:
+	# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(resources, body)
+		}
+	}
+	return resources
+}
+
+get_resources_all_modules = func(type) {
+	resources = []
+	for tfplan.module_paths as path {
+		named_and_counted_resources = tfplan.module(path).resources[type] else {}
+		# Get resource bodies out of nested resource maps, from:
+		# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+		# to:
+		# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+		for named_and_counted_resources as _, instances {
+			for instances as _, body {
+				append(resources, body)
+			}
+		}
 	}
 	return resources
 }

--- a/azurerm-block-allow-all-cidr.sentinel
+++ b/azurerm-block-allow-all-cidr.sentinel
@@ -1,21 +1,32 @@
 import "tfplan"
 
-# Get an array of resource bodies of the given type (each body indexed by count),
-# collected from all modules. (Returns an empty array if none found).
-# Outline of structure:
-# [ {"0": {"applied": {"instance_type": "..."}, "diff": {...}}, "1": {...}},
-#   {"0": {...}},
-#   ... ]
+# Flatten tfplan's nested resource maps:
+#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+# ...to an array of resource bodies:
+#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+get_resource_bodies = func(named_and_counted_resources) {
+	result = []
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(result, body)
+		}
+	}
+	return result
+}
+
+# Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	instances = []
+	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
 		for tfplan.module_paths as path {
-			instances += values(tfplan.module(path).resources[type]) else []
+			nested_resources = tfplan.module(path).resources[type] else {}
+			resources += get_resource_bodies(nested_resources)
 		}
 	} else { # fallback for tests
-		instances += values(tfplan.resources[type]) else []
+		nested_resources = tfplan.resources[type] else {}
+		resources += get_resource_bodies(nested_resources)
 	}
-	return instances
+	return resources
 }
 
 disallowed_cidr_blocks = [
@@ -23,14 +34,10 @@ disallowed_cidr_blocks = [
 	"*",
 ]
 
-security_groups = get_resources("azurerm_network_security_group")
-
 block_allow_all = rule {
-	all security_groups as _index, instances {
-		all instances as _count, sg {
-			all sg.applied.security_rule as _index, sr {
-				(sr.source_address_prefix not in disallowed_cidr_blocks) or sr.access == "Deny"
-			}
+	all get_resources("azurerm_network_security_group") as sg {
+		all sg.applied.security_rule as _, sr {
+			(sr.source_address_prefix not in disallowed_cidr_blocks) or sr.access == "Deny"
 		}
 	}
 }

--- a/azurerm-restrict-vm-size.sentinel
+++ b/azurerm-restrict-vm-size.sentinel
@@ -1,30 +1,42 @@
 import "tfplan"
 
-# Flatten tfplan's nested resource maps:
-#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
-# ...to an array of resource bodies:
-#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
-get_resource_bodies = func(named_and_counted_resources) {
-	result = []
-	for named_and_counted_resources as _, instances {
-		for instances as _, body {
-			append(result, body)
-		}
-	}
-	return result
-}
-
 # Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
-		for tfplan.module_paths as path {
-			nested_resources = tfplan.module(path).resources[type] else {}
-			resources += get_resource_bodies(nested_resources)
-		}
+		return get_resources_all_modules(type)
 	} else { # fallback for tests
-		nested_resources = tfplan.resources[type] else {}
-		resources += get_resource_bodies(nested_resources)
+		return get_resources_root_only(type)
+	}
+}
+
+get_resources_root_only = func(type) {
+	resources = []
+	named_and_counted_resources = tfplan.resources[type] else {}
+	# Get resource bodies out of nested resource maps, from:
+	# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+	# to:
+	# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(resources, body)
+		}
+	}
+	return resources
+}
+
+get_resources_all_modules = func(type) {
+	resources = []
+	for tfplan.module_paths as path {
+		named_and_counted_resources = tfplan.module(path).resources[type] else {}
+		# Get resource bodies out of nested resource maps, from:
+		# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+		# to:
+		# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+		for named_and_counted_resources as _, instances {
+			for instances as _, body {
+				append(resources, body)
+			}
+		}
 	}
 	return resources
 }

--- a/azurerm-restrict-vm-size.sentinel
+++ b/azurerm-restrict-vm-size.sentinel
@@ -1,21 +1,32 @@
 import "tfplan"
 
-# Get an array of resource bodies of the given type (each body indexed by count),
-# collected from all modules. (Returns an empty array if none found).
-# Outline of structure:
-# [ {"0": {"applied": {"instance_type": "..."}, "diff": {...}}, "1": {...}},
-#   {"0": {...}},
-#   ... ]
+# Flatten tfplan's nested resource maps:
+#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+# ...to an array of resource bodies:
+#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+get_resource_bodies = func(named_and_counted_resources) {
+	result = []
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(result, body)
+		}
+	}
+	return result
+}
+
+# Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	instances = []
+	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
 		for tfplan.module_paths as path {
-			instances += values(tfplan.module(path).resources[type]) else []
+			nested_resources = tfplan.module(path).resources[type] else {}
+			resources += get_resource_bodies(nested_resources)
 		}
 	} else { # fallback for tests
-		instances += values(tfplan.resources[type]) else []
+		nested_resources = tfplan.resources[type] else {}
+		resources += get_resource_bodies(nested_resources)
 	}
-	return instances
+	return resources
 }
 
 # comparison is case-sensitive
@@ -36,13 +47,9 @@ allowed_vm_sizes = [
 	"Standard_D2",
 ]
 
-virtual_machines = get_resources("azurerm_virtual_machine")
-
 vm_size_allowed = rule {
-	all virtual_machines as _index, instances {
-		all instances as _count, r {
-			r.applied.vm_size in allowed_vm_sizes
-		}
+	all get_resources("azurerm_virtual_machine") as r {
+		r.applied.vm_size in allowed_vm_sizes
 	}
 }
 

--- a/gcp-block-allow-all-cidr.sentinel
+++ b/gcp-block-allow-all-cidr.sentinel
@@ -1,30 +1,42 @@
 import "tfplan"
 
-# Flatten tfplan's nested resource maps:
-#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
-# ...to an array of resource bodies:
-#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
-get_resource_bodies = func(named_and_counted_resources) {
-	result = []
-	for named_and_counted_resources as _, instances {
-		for instances as _, body {
-			append(result, body)
-		}
-	}
-	return result
-}
-
 # Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
-		for tfplan.module_paths as path {
-			nested_resources = tfplan.module(path).resources[type] else {}
-			resources += get_resource_bodies(nested_resources)
-		}
+		return get_resources_all_modules(type)
 	} else { # fallback for tests
-		nested_resources = tfplan.resources[type] else {}
-		resources += get_resource_bodies(nested_resources)
+		return get_resources_root_only(type)
+	}
+}
+
+get_resources_root_only = func(type) {
+	resources = []
+	named_and_counted_resources = tfplan.resources[type] else {}
+	# Get resource bodies out of nested resource maps, from:
+	# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+	# to:
+	# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(resources, body)
+		}
+	}
+	return resources
+}
+
+get_resources_all_modules = func(type) {
+	resources = []
+	for tfplan.module_paths as path {
+		named_and_counted_resources = tfplan.module(path).resources[type] else {}
+		# Get resource bodies out of nested resource maps, from:
+		# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+		# to:
+		# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+		for named_and_counted_resources as _, instances {
+			for instances as _, body {
+				append(resources, body)
+			}
+		}
 	}
 	return resources
 }

--- a/gcp-block-allow-all-cidr.sentinel
+++ b/gcp-block-allow-all-cidr.sentinel
@@ -1,32 +1,39 @@
 import "tfplan"
 
-# Get an array of resource bodies of the given type (each body indexed by count),
-# collected from all modules. (Returns an empty array if none found).
-# Outline of structure:
-# [ {"0": {"applied": {"instance_type": "..."}, "diff": {...}}, "1": {...}},
-#   {"0": {...}},
-#   ... ]
+# Flatten tfplan's nested resource maps:
+#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+# ...to an array of resource bodies:
+#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+get_resource_bodies = func(named_and_counted_resources) {
+	result = []
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(result, body)
+		}
+	}
+	return result
+}
+
+# Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	instances = []
+	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
 		for tfplan.module_paths as path {
-			instances += values(tfplan.module(path).resources[type]) else []
+			nested_resources = tfplan.module(path).resources[type] else {}
+			resources += get_resource_bodies(nested_resources)
 		}
 	} else { # fallback for tests
-		instances += values(tfplan.resources[type]) else []
+		nested_resources = tfplan.resources[type] else {}
+		resources += get_resource_bodies(nested_resources)
 	}
-	return instances
+	return resources
 }
 
 disallowed_cidr_block = "0.0.0.0/0"
 
-firewalls = get_resources("google_compute_firewall")
-
 block_allow_all = rule {
-	all firewalls as _index, instances {
-		all instances as _count, fw {
-			disallowed_cidr_block not in fw.applied.source_ranges[0]
-		}
+	all get_resources("google_compute_firewall") as fw {
+		disallowed_cidr_block not in fw.applied.source_ranges[0]
 	}
 }
 

--- a/gcp-restrict-machine-type.sentinel
+++ b/gcp-restrict-machine-type.sentinel
@@ -1,30 +1,42 @@
 import "tfplan"
 
-# Flatten tfplan's nested resource maps:
-#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
-# ...to an array of resource bodies:
-#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
-get_resource_bodies = func(named_and_counted_resources) {
-	result = []
-	for named_and_counted_resources as _, instances {
-		for instances as _, body {
-			append(result, body)
-		}
-	}
-	return result
-}
-
 # Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
-		for tfplan.module_paths as path {
-			nested_resources = tfplan.module(path).resources[type] else {}
-			resources += get_resource_bodies(nested_resources)
-		}
+		return get_resources_all_modules(type)
 	} else { # fallback for tests
-		nested_resources = tfplan.resources[type] else {}
-		resources += get_resource_bodies(nested_resources)
+		return get_resources_root_only(type)
+	}
+}
+
+get_resources_root_only = func(type) {
+	resources = []
+	named_and_counted_resources = tfplan.resources[type] else {}
+	# Get resource bodies out of nested resource maps, from:
+	# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+	# to:
+	# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(resources, body)
+		}
+	}
+	return resources
+}
+
+get_resources_all_modules = func(type) {
+	resources = []
+	for tfplan.module_paths as path {
+		named_and_counted_resources = tfplan.module(path).resources[type] else {}
+		# Get resource bodies out of nested resource maps, from:
+		# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+		# to:
+		# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+		for named_and_counted_resources as _, instances {
+			for instances as _, body {
+				append(resources, body)
+			}
+		}
 	}
 	return resources
 }

--- a/gcp-restrict-machine-type.sentinel
+++ b/gcp-restrict-machine-type.sentinel
@@ -1,21 +1,32 @@
 import "tfplan"
 
-# Get an array of resource bodies of the given type (each body indexed by count),
-# collected from all modules. (Returns an empty array if none found).
-# Outline of structure:
-# [ {"0": {"applied": {"instance_type": "..."}, "diff": {...}}, "1": {...}},
-#   {"0": {...}},
-#   ... ]
+# Flatten tfplan's nested resource maps:
+#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+# ...to an array of resource bodies:
+#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+get_resource_bodies = func(named_and_counted_resources) {
+	result = []
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(result, body)
+		}
+	}
+	return result
+}
+
+# Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	instances = []
+	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
 		for tfplan.module_paths as path {
-			instances += values(tfplan.module(path).resources[type]) else []
+			nested_resources = tfplan.module(path).resources[type] else {}
+			resources += get_resource_bodies(nested_resources)
 		}
 	} else { # fallback for tests
-		instances += values(tfplan.resources[type]) else []
+		nested_resources = tfplan.resources[type] else {}
+		resources += get_resource_bodies(nested_resources)
 	}
-	return instances
+	return resources
 }
 
 allowed_machine_types = [
@@ -24,13 +35,9 @@ allowed_machine_types = [
 	"n1-standard-4",
 ]
 
-compute_instances = get_resources("google_compute_instance")
-
 machine_type_allowed = rule {
-	all compute_instances as _index, instances {
-		all instances as _count, r {
-			r.applied.machine_type in allowed_machine_types
-		}
+	all get_resources("google_compute_instance") as r {
+		r.applied.machine_type in allowed_machine_types
 	}
 }
 

--- a/tfe_policies_only.sentinel
+++ b/tfe_policies_only.sentinel
@@ -1,30 +1,42 @@
 import "tfplan"
 
-# Flatten tfplan's nested resource maps:
-#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
-# ...to an array of resource bodies:
-#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
-get_resource_bodies = func(named_and_counted_resources) {
-	result = []
-	for named_and_counted_resources as _, instances {
-		for instances as _, body {
-			append(result, body)
-		}
-	}
-	return result
-}
-
 # Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
-		for tfplan.module_paths as path {
-			nested_resources = tfplan.module(path).resources[type] else {}
-			resources += get_resource_bodies(nested_resources)
-		}
+		return get_resources_all_modules(type)
 	} else { # fallback for tests
-		nested_resources = tfplan.resources[type] else {}
-		resources += get_resource_bodies(nested_resources)
+		return get_resources_root_only(type)
+	}
+}
+
+get_resources_root_only = func(type) {
+	resources = []
+	named_and_counted_resources = tfplan.resources[type] else {}
+	# Get resource bodies out of nested resource maps, from:
+	# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+	# to:
+	# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(resources, body)
+		}
+	}
+	return resources
+}
+
+get_resources_all_modules = func(type) {
+	resources = []
+	for tfplan.module_paths as path {
+		named_and_counted_resources = tfplan.module(path).resources[type] else {}
+		# Get resource bodies out of nested resource maps, from:
+		# {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+		# to:
+		# [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+		for named_and_counted_resources as _, instances {
+			for instances as _, body {
+				append(resources, body)
+			}
+		}
 	}
 	return resources
 }

--- a/tfe_policies_only.sentinel
+++ b/tfe_policies_only.sentinel
@@ -1,21 +1,32 @@
 import "tfplan"
 
-# Get an array of resource bodies of the given type (each body indexed by count),
-# collected from all modules. (Returns an empty array if none found).
-# Outline of structure:
-# [ {"0": {"applied": {"instance_type": "..."}, "diff": {...}}, "1": {...}},
-#   {"0": {...}},
-#   ... ]
+# Flatten tfplan's nested resource maps:
+#   {"name": {"0": {"applied": {...}, "diff": {...} }, "1": {...}}, "name": {...}}
+# ...to an array of resource bodies:
+#   [{"applied": {...}, "diff": {...}}, {"applied": {...}, "diff": {...}}, ...]
+get_resource_bodies = func(named_and_counted_resources) {
+	result = []
+	for named_and_counted_resources as _, instances {
+		for instances as _, body {
+			append(result, body)
+		}
+	}
+	return result
+}
+
+# Get an array of all resources of the given type (or an empty array).
 get_resources = func(type) {
-	instances = []
+	resources = []
 	if length(tfplan.module_paths else []) > 0 { # always true in the real tfplan import
 		for tfplan.module_paths as path {
-			instances += values(tfplan.module(path).resources[type]) else []
+			nested_resources = tfplan.module(path).resources[type] else {}
+			resources += get_resource_bodies(nested_resources)
 		}
 	} else { # fallback for tests
-		instances += values(tfplan.resources[type]) else []
+		nested_resources = tfplan.resources[type] else {}
+		resources += get_resource_bodies(nested_resources)
 	}
-	return instances
+	return resources
 }
 
 no_tfe_organization = rule { length(get_resources("tfe_organization")) == 0 }


### PR DESCRIPTION
In all of these cases, we were having to deal with deeply nested data structures
way too late in the policy, making the _policy_ part of it harder to read. By
moving all the nested data structure logic into one helper function, we can make
the important part of the policy more legible.